### PR TITLE
Replaced Midgard with Imperial Federation in brewery.md

### DIFF
--- a/pages/plugins/fun/brewery.md
+++ b/pages/plugins/fun/brewery.md
@@ -282,132 +282,132 @@ Brews that provide unique/usefull effects
 ### Nation Brews
 Brews that are part of a nation or group's PR/culture and were submitted by them.
 
-|  Nation/Group   |             Name             | Ingredient Amount | Texture ID |
-|:---------------:|:----------------------------:|:-----------------:|:----------:|
-|     Icenia      |       Icenian Pale Ale       |         4         |   700001   |
-|     Dalgon      |         Dalgon Pale          |         3         |   700002   |
-|      Pacem      |        Pacem Pilsner         |         3         |   700003   |
-|       MTA       |        Augustan Cider        |         2         |   700004   |
-|     Wolken      |       Wolken White Ale       |         5         |   700005   |
-|   Southshire    |       Southshire Stout       |         6         |   700006   |
-|       MTS       |  Septembrian Summer Breeze   |         2         |   700007   |
-|  Commonwealth   |   Commonwealth Chardonnay    |         4         |   700008   |
-|       CDM       |      Cortesian Chianti       |         3         |   700009   |
-|      Sovia      |       Cabernet Sovian        |         2         |   700010   |
-|    Lusitania    |         Lusitan Wine         |         3         |   700011   |
-|     Fempire     |    Fempire Sparkling Rose    |         4         |   700012   |
-|      Nara       |     Nara Pufferfish Wine     |         4         |   700013   |
-|      CCTT       |      CCTT Pumpkin Wine       |         3         |   700014   |
-|      Dirt       |          Dirt Wine           |         3         |   700015   |
-|      Pavia      |        Pavian Wiskey         |         4         |   700016   |
-|     Fempire     |          Fembourbon          |         4         |   700017   |
-|     Griffin     |     Griffin Gold Whiskey     |         4         |   700018   |
-|      Nara       |        Nara no Uisuki        |         4         |   700019   |
-|    Gensokyo     |    Gensokyo no Ginjo Sake    |         3         |   700020   |
-|      Venne      |         Venne Vodka          |         4         |   700021   |
-|  Winterbourne   |   Winterbourne Wheat Vodka   |         4         |   700022   |
-|     Estalia     |      Estalian Schnapps       |         5         |   700023   |
-|   Southshire    |   Southshire Cream Liquer    |         5         |   700024   |
-|       Ku        |           Kubucha            |         5         |   700025   |
-|     Yoathl      |           Yoahpple           |         3         |   700026   |
-|     Lambat      |          Lambasiat           |         4         |   700027   |
-|     Yoathl      |       Chicha Alchuahtl       |         6         |   700028   |
-| Banana Republic |     Banana Republic Mead     |         4         |   700029   |
-|      Venne      |           Vennessy           |         3         |   700030   |
-|      Mery       |      Smiles of T'shola       |         3         |   700031   |
-|   Danzelonia    |       Dandedanzilonia        |         5         |   700032   |
-|    Maseters     |        JaegerMaester         |         8         |   700033   |
-|   Southshire    |   Shaken Southsire Sunset    |         4         |   700034   |
-|      Pacem      |         Pacem Proper         |         4         |   700035   |
-|      Venne      |       Venne Cream Soda       |         4         |   700036   |
-|     Valyria     |     Valyrian Dragonwine      |         4         |   700037   |
-|   Wheatistan    | Wheatistan Whimsical Whiskey |         3         |   700038   |
-|   Danzilonia    |       Danzilonian Wine       |         4         |   700039   |
-|    Butternut    |  Butternut Pumpkin Bourbon   |         6         |   700040   |
-|   New Phoenix   |   New Phoenix Fire Whiskey   |         3         |   700041   |
-|   Pridelands    |       Pridelands Mead        |         3         |   700042   |
-|     Acadia      |       Acadian Absinthe       |         4         |   700043   |
-|     Icenia      |      Icenian Icebreaker      |         4         |   700044   |
-|    Civmarket    |      CivMarket Chowder       |         6         |   700045   |
-| Margaritaville  |   Margaritaville Margarita   |         6         |   700046   |
-|     Estalia     |        Vault Breaker         |         2         |   700047   |
-|     Icarus      |         Nuclear Milk         |         4         |   700048   |
-|     Amboise     |       Amboise Red Wine       |         3         |   700049   |
-|      Atlas      |       Atlas Corp Cuban       |         4         |   700050   |
-|      Eire       |        Irish whiskey         |         3         |   700051   |
-| Grand Imperium  |       Imperian Whiskey       |         3         |   700052   |
-|     Warmia      |        Warmian Nitro         |         3         |   700053   |
-|      Nara       |        Shiroyama Sake        |         4         |   700054   |
-| Grand Imperium  |             Ixi              |         2         |   700055   |
-| Grand Imperium  |    Imperian Carrot Juice     |         2         |   700056   |
-|     Warmia      |         Angmar Vodka         |         3         |   700057   |
-|      SPQR       |    Mint Chocolate Martini    |         4         |   700058   |
-|     Reggio      |          Reggio Rum          |         5         |   700059   |
-|    Gang Shi     |   The Shitter's Brown Ale    |         3         |   700060   |
-| Temporal Isles  |   Temporal Sweet Red Wine    |         4         |   700061   |
-|    Attoprak     |        Secret Sprite         |         4         |   700062   |
-|     Icarus      |         Boar Bourbon         |         3         |   700063   |
-|      Joja       |          Joja Cola           |         4         |   700064   |
-|    Brunsvilk    |      Brunsvilk Jenever       |         5         |   700065   |
-|     Zanaris     | Zanarian Razzleberry Delight |         5         |   700066   |
-|     Zanaris     |        Faerie's Kiss         |         4         |   700067   |
-|     XXXCIOS     |       Fruity Tooty Mix       |         4         |   700068   |
-|   Bazariškės    |         Naminė Gira          |         4         |   700069   |
-|     Griffin     |      Griffin Rose Wine       |         3         |   700070   |
-| Temporal Isles  |   Temporal Tropical Punch    |         4         |   700071   |
-|  Transylvania   |         Cluj pálinka         |         3         |   700072   |
-|     Griffin     |       Sealeo Rum Punch       |         3         |   700073   |
-|      Spqr       |     Spicy Vodka Espresso     |         4         |   700074   |
-|     Griffin     |     Griffin Melon Cider      |         2         |   700075   |
-|     Reggio      |       Reggio Surprise        |         4         |   700076   |
-|    Tortugain    |           Rosy Rum           |         3         |   700077   |
-|    Bergburg     |         Bergburgbier         |         4         |   700078   |
-|    Brunsvilk    |    Brunsvilk Sewage Water    |         5         |   700079   |
-|      Iria       |     Irian Jungle Coffee      |         4         |   700080   |
-|     Thoria      |        Thorian Cider         |         4         |   700081   |
-|    Nro'meagh    |        Jevoghnya Brew        |         4         |   700082   |
-|   Ila'Kyavul    |          Greek Fire          |         3         |   700083   |
-|     Larauve     |    Larauve Medicinal Tea     |         4         |   700084   |
-|      Bloom      |            Slushy            |         4         |   700085   |
-|    Volterra     |         Tendie Tonic         |         4         |   700086   |
-|    Volterra     |          Volt Vodka          |         3         |   700087   |
-|      Aeros      |          Aeros Ale           |         3         |   700088   |
-|     Cordoba     |         VB Longneck          |         3         |   700089   |
-|     Yoathl      |         Gin of Rails         |         3         |   700090   |
-|     Yoathl      |         Kobeerlinski         |         3         |   700091   |
-|    Freeport     |     Frihavn Juniper Ale      |         4         |   700092   |
-|    Freeport     |          Fen Fyool           |         5         |   700093   |
-|     Midgar      |       Burning Blizzard       |         4         |   700094   |
-|     Larauve     |      Larauve Bubble Tea      |         4         |   700095   |
-|  Winterbourne   |  Winterbourne Lamb Knuckle   |         3         |   700096   |
-|  Winterbourne   |          Winterale           |         3         |   700097   |
-|  Winterbourne   |    Winterbourne Blue Ice     |         3         |   700098   |
-| Banana Republic |  Banana Republic Pickleback  |         2         |   700099   |
-|    Meracydia    |   Meracydian Mulled Cider    |         7         |   700100   |
-|    Meracydia    |   Valar Winter Cheesecake    |         7         |   700101   |
-|    Meracydia    |       Meracydian Mule        |         5         |   700102   |
-|    Meracydia    |    Valar Steamfired Soda     |         6         |   700103   |
-|     Larauve     |       Larauve Shortcut       |         5         |   700104   |
-|      Vald       |          Vald Mead           |         4         |   700105   |
-|     Estalia     |            Donut             |         5         |   700106   |
-|      Gmall      |          Gmall Grog          |         4         |   700107   |
-|    Doom City    |         Doom Delight         |         5         |   700108   |
-|  Grebada State  |    Grenada Club White Rum    |         3         |   700109   |
-|   New Jersey    |   Cranberry Juice Cocktail   |         4         |   700110   |
-|    Hispania     |    Walloon Guard Whiskey     |         3         |   700111   |
-|    Hispania     |     Line Infantry Lager      |         3         |   700112   |
-| Catholic Church |       Sacramental Wine       |         2         |   700113   |
-|       SEC       |  Security Enhancement Cider  |         3         |   700114   |
-|   Greenfaith    |      Greenfaith Goulash      |         4         |   700115   |
-|   Greenfaith    |     Trailblazer's Toddy      |         4         |   700116   |
-|     Icaraki     |           Icaraki            |         2         |   700117   |
-|   Truidencia    |       Nidaros Akevitt        |         2         |   700118   |
-|   Truidencia    |          Warm Milk           |         2         |   700119   |
-|    Amicitia     |       Amicitian Lager        |         4         |   700120   |
-|     Kaowta      |     Kaowtanese Melonale      |         3         |   700121   |
-|    ICE Labs     |         Cocaine Cola         |         6         |   700122   |
-|      Bloom      |        Bloomin' Onion        |         1         |   700123   |
-|      Baile      |         Azarath Mead         |         4         |   700124   |
+|    Nation/Group     |             Name             | Ingredient Amount | Texture ID |
+|:-------------------:|:----------------------------:|:-----------------:|:----------:|
+|       Icenia        |       Icenian Pale Ale       |         4         |   700001   |
+|       Dalgon        |         Dalgon Pale          |         3         |   700002   |
+|        Pacem        |        Pacem Pilsner         |         3         |   700003   |
+|         MTA         |        Augustan Cider        |         2         |   700004   |
+|       Wolken        |       Wolken White Ale       |         5         |   700005   |
+|     Southshire      |       Southshire Stout       |         6         |   700006   |
+|         MTS         |  Septembrian Summer Breeze   |         2         |   700007   |
+|    Commonwealth     |   Commonwealth Chardonnay    |         4         |   700008   |
+|         CDM         |      Cortesian Chianti       |         3         |   700009   |
+|        Sovia        |       Cabernet Sovian        |         2         |   700010   |
+|      Lusitania      |         Lusitan Wine         |         3         |   700011   |
+|       Fempire       |    Fempire Sparkling Rose    |         4         |   700012   |
+|        Nara         |     Nara Pufferfish Wine     |         4         |   700013   |
+|        CCTT         |      CCTT Pumpkin Wine       |         3         |   700014   |
+|        Dirt         |          Dirt Wine           |         3         |   700015   |
+|        Pavia        |        Pavian Wiskey         |         4         |   700016   |
+|       Fempire       |          Fembourbon          |         4         |   700017   |
+|       Griffin       |     Griffin Gold Whiskey     |         4         |   700018   |
+|        Nara         |        Nara no Uisuki        |         4         |   700019   |
+|      Gensokyo       |    Gensokyo no Ginjo Sake    |         3         |   700020   |
+|        Venne        |         Venne Vodka          |         4         |   700021   |
+|    Winterbourne     |   Winterbourne Wheat Vodka   |         4         |   700022   |
+|       Estalia       |      Estalian Schnapps       |         5         |   700023   |
+|     Southshire      |   Southshire Cream Liquer    |         5         |   700024   |
+|         Ku          |           Kubucha            |         5         |   700025   |
+|       Yoathl        |           Yoahpple           |         3         |   700026   |
+|       Lambat        |          Lambasiat           |         4         |   700027   |
+|       Yoathl        |       Chicha Alchuahtl       |         6         |   700028   |
+|   Banana Republic   |     Banana Republic Mead     |         4         |   700029   |
+|        Venne        |           Vennessy           |         3         |   700030   |
+|        Mery         |      Smiles of T'shola       |         3         |   700031   |
+|     Danzelonia      |       Dandedanzilonia        |         5         |   700032   |
+|      Maseters       |        JaegerMaester         |         8         |   700033   |
+|     Southshire      |   Shaken Southsire Sunset    |         4         |   700034   |
+|        Pacem        |         Pacem Proper         |         4         |   700035   |
+|        Venne        |       Venne Cream Soda       |         4         |   700036   |
+|       Valyria       |     Valyrian Dragonwine      |         4         |   700037   |
+|     Wheatistan      | Wheatistan Whimsical Whiskey |         3         |   700038   |
+|     Danzilonia      |       Danzilonian Wine       |         4         |   700039   |
+|      Butternut      |  Butternut Pumpkin Bourbon   |         6         |   700040   |
+|     New Phoenix     |   New Phoenix Fire Whiskey   |         3         |   700041   |
+|     Pridelands      |       Pridelands Mead        |         3         |   700042   |
+|       Acadia        |       Acadian Absinthe       |         4         |   700043   |
+|       Icenia        |      Icenian Icebreaker      |         4         |   700044   |
+|      Civmarket      |      CivMarket Chowder       |         6         |   700045   |
+|   Margaritaville    |   Margaritaville Margarita   |         6         |   700046   |
+|       Estalia       |        Vault Breaker         |         2         |   700047   |
+|       Icarus        |         Nuclear Milk         |         4         |   700048   |
+|       Amboise       |       Amboise Red Wine       |         3         |   700049   |
+|        Atlas        |       Atlas Corp Cuban       |         4         |   700050   |
+|        Eire         |        Irish whiskey         |         3         |   700051   |
+|   Grand Imperium    |       Imperian Whiskey       |         3         |   700052   |
+|       Warmia        |        Warmian Nitro         |         3         |   700053   |
+|        Nara         |        Shiroyama Sake        |         4         |   700054   |
+|   Grand Imperium    |             Ixi              |         2         |   700055   |
+|   Grand Imperium    |    Imperian Carrot Juice     |         2         |   700056   |
+|       Warmia        |         Angmar Vodka         |         3         |   700057   |
+|        SPQR         |    Mint Chocolate Martini    |         4         |   700058   |
+|       Reggio        |          Reggio Rum          |         5         |   700059   |
+|      Gang Shi       |   The Shitter's Brown Ale    |         3         |   700060   |
+|   Temporal Isles    |   Temporal Sweet Red Wine    |         4         |   700061   |
+|      Attoprak       |        Secret Sprite         |         4         |   700062   |
+|       Icarus        |         Boar Bourbon         |         3         |   700063   |
+|        Joja         |          Joja Cola           |         4         |   700064   |
+|      Brunsvilk      |      Brunsvilk Jenever       |         5         |   700065   |
+|       Zanaris       | Zanarian Razzleberry Delight |         5         |   700066   |
+|       Zanaris       |        Faerie's Kiss         |         4         |   700067   |
+|       XXXCIOS       |       Fruity Tooty Mix       |         4         |   700068   |
+|     Bazariškės      |         Naminė Gira          |         4         |   700069   |
+|       Griffin       |      Griffin Rose Wine       |         3         |   700070   |
+|   Temporal Isles    |   Temporal Tropical Punch    |         4         |   700071   |
+|    Transylvania     |         Cluj pálinka         |         3         |   700072   |
+|       Griffin       |       Sealeo Rum Punch       |         3         |   700073   |
+|        Spqr         |     Spicy Vodka Espresso     |         4         |   700074   |
+|       Griffin       |     Griffin Melon Cider      |         2         |   700075   |
+|       Reggio        |       Reggio Surprise        |         4         |   700076   |
+|      Tortugain      |           Rosy Rum           |         3         |   700077   |
+|      Bergburg       |         Bergburgbier         |         4         |   700078   |
+|      Brunsvilk      |    Brunsvilk Sewage Water    |         5         |   700079   |
+|        Iria         |     Irian Jungle Coffee      |         4         |   700080   |
+|       Thoria        |        Thorian Cider         |         4         |   700081   |
+|      Nro'meagh      |        Jevoghnya Brew        |         4         |   700082   |
+|     Ila'Kyavul      |          Greek Fire          |         3         |   700083   |
+|       Larauve       |    Larauve Medicinal Tea     |         4         |   700084   |
+|        Bloom        |            Slushy            |         4         |   700085   |
+|      Volterra       |         Tendie Tonic         |         4         |   700086   |
+|      Volterra       |          Volt Vodka          |         3         |   700087   |
+|        Aeros        |          Aeros Ale           |         3         |   700088   |
+|       Cordoba       |         VB Longneck          |         3         |   700089   |
+|       Yoathl        |         Gin of Rails         |         3         |   700090   |
+|       Yoathl        |         Kobeerlinski         |         3         |   700091   |
+|      Freeport       |     Frihavn Juniper Ale      |         4         |   700092   |
+|      Freeport       |          Fen Fyool           |         5         |   700093   |
+| Imperial Federation |       Burning Blizzard       |         4         |   700094   |
+|       Larauve       |      Larauve Bubble Tea      |         4         |   700095   |
+|    Winterbourne     |  Winterbourne Lamb Knuckle   |         3         |   700096   |
+|    Winterbourne     |          Winterale           |         3         |   700097   |
+|    Winterbourne     |    Winterbourne Blue Ice     |         3         |   700098   |
+|   Banana Republic   |  Banana Republic Pickleback  |         2         |   700099   |
+|      Meracydia      |   Meracydian Mulled Cider    |         7         |   700100   |
+|      Meracydia      |   Valar Winter Cheesecake    |         7         |   700101   |
+|      Meracydia      |       Meracydian Mule        |         5         |   700102   |
+|      Meracydia      |    Valar Steamfired Soda     |         6         |   700103   |
+|       Larauve       |       Larauve Shortcut       |         5         |   700104   |
+|        Vald         |          Vald Mead           |         4         |   700105   |
+|       Estalia       |            Donut             |         5         |   700106   |
+|        Gmall        |          Gmall Grog          |         4         |   700107   |
+|      Doom City      |         Doom Delight         |         5         |   700108   |
+|    Grebada State    |    Grenada Club White Rum    |         3         |   700109   |
+|     New Jersey      |   Cranberry Juice Cocktail   |         4         |   700110   |
+|      Hispania       |    Walloon Guard Whiskey     |         3         |   700111   |
+|      Hispania       |     Line Infantry Lager      |         3         |   700112   |
+|   Catholic Church   |       Sacramental Wine       |         2         |   700113   |
+|         SEC         |  Security Enhancement Cider  |         3         |   700114   |
+|     Greenfaith      |      Greenfaith Goulash      |         4         |   700115   |
+|     Greenfaith      |     Trailblazer's Toddy      |         4         |   700116   |
+|       Icaraki       |           Icaraki            |         2         |   700117   |
+|     Truidencia      |       Nidaros Akevitt        |         2         |   700118   |
+|     Truidencia      |          Warm Milk           |         2         |   700119   |
+|      Amicitia       |       Amicitian Lager        |         4         |   700120   |
+|       Kaowta        |     Kaowtanese Melonale      |         3         |   700121   |
+|      ICE Labs       |         Cocaine Cola         |         6         |   700122   |
+|        Bloom        |        Bloomin' Onion        |         1         |   700123   |
+|        Baile        |         Azarath Mead         |         4         |   700124   |
 
 ### Player Brews
 Brews specific to individuals either for their contribution to the genre/server


### PR DESCRIPTION
When the government officials in the Imperial Federation (IF) requested for their own national brew, Asgard didn't existed until by the time Burning Blizzard got added, Asgard was a thing and apparently told the admins that it was Midgard who came up with that idea instead of the Imperial Federation, the original nation who came up with this.

We would be greatly appreciated to have this pull approved as it was the whole IF's idea.

Also I fixed formatting so it doesn't look ugly in source code